### PR TITLE
Change build: no CGO dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 ADD . .
 
-RUN go build -o ./bin/algorun *.go
+RUN CGO_ENABLED=0 go build -o ./bin/algorun *.go
 
 FROM algorand/algod:latest
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 build:
-	go build -o bin/algorun *.go
+	CGO_ENABLED=0 go build -o bin/algorun *.go
 test:
 	go test -coverpkg=./... -covermode=atomic ./...
 generate:


### PR DESCRIPTION
Removing the CGO/GLIBC dependency will make our binaries more portable (at the expense of larger binaries)

I have already had an issue on an ubuntu 20.04.6 node if I build with the default (CGO yes):

```
./algorun: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by ./algorun)
./algorun: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by ./algorun)
```