### PR TITLE
fix: show expired keys

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -79,8 +79,8 @@ var (
 				Client:  client,
 				Context: ctx,
 			}
-			state.Accounts = internal.AccountsFromState(&state, new(internal.Clock), client)
-
+			state.Accounts, err = internal.AccountsFromState(&state, new(internal.Clock), client)
+			cobra.CheckErr(err)
 			// Fetch current state
 			err = state.Status.Fetch(ctx, client, new(internal.HttpPkg))
 			cobra.CheckErr(err)

--- a/internal/accounts.go
+++ b/internal/accounts.go
@@ -135,7 +135,7 @@ func UpdateAccountExpiredTime(t Time, account Account, state *StateModel) Accoun
 	var nonResidentKey = true
 	for _, key := range *state.ParticipationKeys {
 		// We have the key locally, update the residency
-		if key.Address == account.Address && account.Participation != nil && IsParticipationKeyActive(key, *account.Participation) {
+		if account.Status == "Offline" || (key.Address == account.Address && account.Participation != nil && IsParticipationKeyActive(key, *account.Participation)) {
 			nonResidentKey = false
 		}
 	}

--- a/internal/accounts.go
+++ b/internal/accounts.go
@@ -16,6 +16,8 @@ type Account struct {
 	Participation *api.AccountParticipation
 	// IncentiveEligible determines the minimum fee
 	IncentiveEligible bool
+	// NonResidentKey finds an online account that is missing locally
+	NonResidentKey bool
 	// Account Address is the algorand encoded address
 	Address string
 	// Status is the Online/Offline/"NotParticipating" status of the account
@@ -30,7 +32,7 @@ type Account struct {
 	Expires *time.Time
 }
 
-// Get Online Status of Account
+// GetAccount status of api.Account
 func GetAccount(client api.ClientWithResponsesInterface, address string) (api.Account, error) {
 	var format api.AccountInformationParamsFormat = "json"
 	r, err := client.AccountInformationWithResponse(
@@ -53,74 +55,116 @@ func GetAccount(client api.ClientWithResponsesInterface, address string) (api.Ac
 }
 
 // GetExpiresTime calculates and returns the expiration time for a participation key based on the current account state.
-func GetExpiresTime(t Time, key api.ParticipationKey, state *StateModel) *time.Time {
+func GetExpiresTime(t Time, lastRound int, roundTime time.Duration, account Account) *time.Time {
 	now := t.Now()
 	var expires time.Time
-	if state.Accounts[key.Address].Status == "Online" &&
-		state.Accounts[key.Address].Participation != nil &&
-		bytes.Equal(*state.Accounts[key.Address].Participation.StateProofKey, *key.Key.StateProofKey) &&
-		state.Status.LastRound != 0 &&
-		state.Metrics.RoundTime != 0 {
-		roundDiff := max(0, key.Key.VoteLastValid-int(state.Status.LastRound))
-		distance := int(state.Metrics.RoundTime) * roundDiff
+	if account.Status == "Online" &&
+		account.Participation != nil &&
+		lastRound != 0 &&
+		roundTime != 0 {
+		roundDiff := max(0, account.Participation.VoteLastValid-int(lastRound))
+		distance := int(roundTime) * roundDiff
 		expires = now.Add(time.Duration(distance))
 		return &expires
 	}
 	return nil
 }
 
-// AccountsFromParticipationKeys maps an array of api.ParticipationKey to a keyed map of Account
-func AccountsFromState(state *StateModel, t Time, client api.ClientWithResponsesInterface) map[string]Account {
-	values := make(map[string]Account)
-	if state == nil || state.ParticipationKeys == nil {
-		return values
+// ParticipationKeysToAccounts converts a slice of ParticipationKey objects into a map of Account objects.
+// The keys parameter is a slice of pointers to ParticipationKey instances.
+// The prev parameter is an optional map that allows merging of existing accounts with new ones.
+// Returns a map where each key is an address from a ParticipationKey, and the value is a corresponding Account.
+func ParticipationKeysToAccounts(keys *[]api.ParticipationKey) map[string]Account {
+	// Allow merging of existing accounts
+	var accounts = make(map[string]Account)
+
+	// Must have keys to process
+	if keys == nil {
+		return accounts
 	}
-	for _, key := range *state.ParticipationKeys {
-		val, ok := values[key.Address]
-		if !ok {
-			var account = api.Account{
+
+	// Add missing Accounts
+	for _, key := range *keys {
+		if _, ok := accounts[key.Address]; !ok {
+			accounts[key.Address] = Account{
+				Participation:     nil,
+				IncentiveEligible: false,
 				Address:           key.Address,
 				Status:            "Unknown",
-				IncentiveEligible: nil,
-				Amount:            0,
-			}
-			if state.Status.State != SyncingState {
-				var err error
-				account, err = GetAccount(client, key.Address)
-				// TODO: handle error
-				if err != nil {
-					// TODO: Logging
-					panic(err)
-				}
-			}
-
-			// Check for eligibility
-			var incentiveEligible = false
-			if account.IncentiveEligible == nil {
-				incentiveEligible = false
-			} else {
-				incentiveEligible = *account.IncentiveEligible
-			}
-			values[key.Address] = Account{
-				Participation:     account.Participation,
-				Address:           key.Address,
-				Status:            account.Status,
-				Balance:           account.Amount / 1000000,
-				Expires:           GetExpiresTime(t, key, state),
-				IncentiveEligible: incentiveEligible,
+				Balance:           0,
 				Keys:              1,
+				Expires:           nil,
 			}
 		} else {
-			val.Keys++
-			if val.Participation != nil &&
-				bytes.Equal(*val.Participation.StateProofKey, *key.Key.StateProofKey) {
-				val.Expires = GetExpiresTime(t, key, state)
+			acct := accounts[key.Address]
+			acct.Keys++
+			accounts[key.Address] = acct
+		}
+	}
+	return accounts
+}
+
+func UpdateAccountFromRPC(account Account, rpcAccount api.Account) Account {
+	account.Status = rpcAccount.Status
+	account.Balance = rpcAccount.Amount / 1000000
+	account.Participation = rpcAccount.Participation
+
+	var incentiveEligible = false
+	if rpcAccount.IncentiveEligible == nil {
+		incentiveEligible = false
+	} else {
+		incentiveEligible = *rpcAccount.IncentiveEligible
+	}
+
+	account.IncentiveEligible = incentiveEligible
+
+	return account
+}
+
+func IsParticipationKeyActive(part api.ParticipationKey, account api.AccountParticipation) bool {
+	var equal = false
+	if bytes.Equal(part.Key.VoteParticipationKey, account.VoteParticipationKey) &&
+		part.Key.VoteLastValid == account.VoteLastValid &&
+		part.Key.VoteFirstValid == account.VoteFirstValid {
+		equal = true
+	}
+	return equal
+}
+
+func UpdateAccountExpiredTime(t Time, account Account, state *StateModel) Account {
+	var nonResidentKey = true
+	for _, key := range *state.ParticipationKeys {
+		// We have the key locally, update the residency
+		if key.Address == account.Address && account.Participation != nil && IsParticipationKeyActive(key, *account.Participation) {
+			nonResidentKey = false
+		}
+	}
+	account.NonResidentKey = nonResidentKey
+	account.Expires = GetExpiresTime(t, int(state.Status.LastRound), state.Metrics.RoundTime, account)
+	return account
+}
+
+// AccountsFromState maps an array of api.ParticipationKey to a keyed map of Account
+func AccountsFromState(state *StateModel, t Time, client api.ClientWithResponsesInterface) (map[string]Account, error) {
+	if state == nil {
+		return make(map[string]Account), nil
+	}
+
+	accounts := ParticipationKeysToAccounts(state.ParticipationKeys)
+
+	for _, acct := range accounts {
+		// For each account, update the data from the RPC endpoint
+		if state.Status.State != SyncingState {
+			rpcAcct, err := GetAccount(client, acct.Address)
+			if err != nil {
+				return nil, err
 			}
-			values[key.Address] = val
+			accounts[acct.Address] = UpdateAccountFromRPC(acct, rpcAcct)
+			accounts[acct.Address] = UpdateAccountExpiredTime(t, accounts[acct.Address], state)
 		}
 	}
 
-	return values
+	return accounts, nil
 }
 
 func ValidateAddress(address string) bool {

--- a/internal/state.go
+++ b/internal/state.go
@@ -125,8 +125,10 @@ func (s *StateModel) UpdateMetricsFromRPC(ctx context.Context, client api.Client
 		s.Metrics.LastRX = res["algod_network_received_bytes_total"]
 	}
 }
-func (s *StateModel) UpdateAccounts() {
-	s.Accounts = AccountsFromState(s, new(Clock), s.Client)
+func (s *StateModel) UpdateAccounts() error {
+	var err error
+	s.Accounts, err = AccountsFromState(s, new(Clock), s.Client)
+	return err
 }
 
 func (s *StateModel) UpdateKeys() {
@@ -137,6 +139,9 @@ func (s *StateModel) UpdateKeys() {
 	}
 	if err == nil {
 		s.Admin = true
-		s.UpdateAccounts()
+		err = s.UpdateAccounts()
+		if err != nil {
+			// TODO: Handle error
+		}
 	}
 }

--- a/internal/test/client.go
+++ b/internal/test/client.go
@@ -156,6 +156,18 @@ func (c *Client) DeleteParticipationKeyByIDWithResponse(ctx context.Context, par
 	return &res, nil
 }
 
+func (c *Client) AccountInformationWithResponse(ctx context.Context, address string, params *api.AccountInformationParams, reqEditors ...api.RequestEditorFn) (*api.AccountInformationResponse, error) {
+	httpResponse := http.Response{StatusCode: 200}
+	return &api.AccountInformationResponse{
+		Body:         nil,
+		HTTPResponse: &httpResponse,
+		JSON200:      &mock.ABCAccount,
+		JSON400:      nil,
+		JSON401:      nil,
+		JSON500:      nil,
+	}, nil
+}
+
 func (c *Client) GenerateParticipationKeysWithResponse(ctx context.Context, address string, params *api.GenerateParticipationKeysParams, reqEditors ...api.RequestEditorFn) (*api.GenerateParticipationKeysResponse, error) {
 	mock.Keys = append(mock.Keys, api.ParticipationKey{
 		Address:             "ABC",

--- a/internal/test/mock/fixtures.go
+++ b/internal/test/mock/fixtures.go
@@ -7,6 +7,7 @@ import (
 var VoteKey = []byte("TESTKEY")
 var SelectionKey = []byte("TESTKEY")
 var StateProofKey = []byte("TESTKEY")
+var StateProofKeyTwo = []byte("TESTKEYTWO")
 var Keys = []api.ParticipationKey{
 	{
 		Address:             "ABC",
@@ -32,7 +33,7 @@ var Keys = []api.ParticipationKey{
 		Id:                  "1234",
 		Key: api.AccountParticipation{
 			SelectionParticipationKey: nil,
-			StateProofKey:             nil,
+			StateProofKey:             &StateProofKeyTwo,
 			VoteFirstValid:            0,
 			VoteKeyDilution:           100,
 			VoteLastValid:             30000,
@@ -42,4 +43,43 @@ var Keys = []api.ParticipationKey{
 		LastStateProof:    nil,
 		LastVote:          nil,
 	},
+}
+var abcEligibility = true
+
+var abcParticipation = api.AccountParticipation{
+	SelectionParticipationKey: SelectionKey,
+	StateProofKey:             &StateProofKey,
+	VoteFirstValid:            0,
+	VoteKeyDilution:           100,
+	VoteLastValid:             30000,
+	VoteParticipationKey:      VoteKey,
+}
+var ABCAccount = api.Account{
+	Address:                     "ABC",
+	Amount:                      100000,
+	AmountWithoutPendingRewards: 0,
+	AppsLocalState:              nil,
+	AppsTotalExtraPages:         nil,
+	AppsTotalSchema:             nil,
+	Assets:                      nil,
+	AuthAddr:                    nil,
+	CreatedApps:                 nil,
+	CreatedAssets:               nil,
+	IncentiveEligible:           &abcEligibility,
+	LastHeartbeat:               nil,
+	LastProposed:                nil,
+	MinBalance:                  0,
+	Participation:               &abcParticipation,
+	PendingRewards:              0,
+	RewardBase:                  nil,
+	Rewards:                     0,
+	Round:                       0,
+	SigType:                     nil,
+	Status:                      "Online",
+	TotalAppsOptedIn:            0,
+	TotalAssetsOptedIn:          0,
+	TotalBoxBytes:               nil,
+	TotalBoxes:                  nil,
+	TotalCreatedApps:            0,
+	TotalCreatedAssets:          0,
 }

--- a/ui/internal/test/state.go
+++ b/ui/internal/test/state.go
@@ -37,7 +37,6 @@ func GetState(client api.ClientWithResponsesInterface) *internal.StateModel {
 		Context:           context.Background(),
 	}
 	values := make(map[string]internal.Account)
-	clock := new(mock2.Clock)
 	for _, key := range *sm.ParticipationKeys {
 		val, ok := values[key.Address]
 		if !ok {
@@ -46,7 +45,7 @@ func GetState(client api.ClientWithResponsesInterface) *internal.StateModel {
 				Status:            "Offline",
 				Balance:           0,
 				IncentiveEligible: true,
-				Expires:           internal.GetExpiresTime(clock, key, sm),
+				Expires:           nil,
 				Keys:              1,
 			}
 		} else {

--- a/ui/pages/accounts/model.go
+++ b/ui/pages/accounts/model.go
@@ -77,19 +77,19 @@ func (m ViewModel) makeColumns(width int) []table.Column {
 func (m ViewModel) makeRows() *[]table.Row {
 	rows := make([]table.Row, 0)
 
-	for key := range m.Data.Accounts {
+	for addr := range m.Data.Accounts {
 		var expires = "N/A"
-		if m.Data.Accounts[key].Expires != nil {
+		if m.Data.Accounts[addr].Expires != nil {
 			// This condition will only exist for a split second
 			// until algod deletes the key
-			if m.Data.Accounts[key].Expires.Before(time.Now()) {
+			if m.Data.Accounts[addr].Expires.Before(time.Now()) {
 				expires = "EXPIRED"
 			} else {
-				expires = m.Data.Accounts[key].Expires.Format(time.RFC822)
+				expires = m.Data.Accounts[addr].Expires.Format(time.RFC822)
 			}
 
 			// Expires within the week
-			if m.Data.Accounts[key].Expires.Before(time.Now().Add(time.Hour * 24 * 7)) {
+			if m.Data.Accounts[addr].Expires.Before(time.Now().Add(time.Hour * 24 * 7)) {
 				expires = "⚠ " + expires
 			}
 		}
@@ -99,16 +99,20 @@ func (m ViewModel) makeRows() *[]table.Row {
 			expires = "SYNCING"
 		}
 
-		if m.Data.Accounts[key].Status == "Online" && expires == "N/A" && m.Data.Accounts[key].Expires != nil {
-			expires = "⚠ NON-RESIDENT-KEY"
+		if m.Data.Accounts[addr].NonResidentKey {
+			if expires == "⚠ EXPIRED" {
+				expires = "⚠ EXPIRED-NON-RESIDENT-KEY"
+			} else {
+				expires = "⚠ NON-RESIDENT-KEY"
+			}
 		}
 
 		rows = append(rows, table.Row{
-			m.Data.Accounts[key].Address,
-			strconv.Itoa(m.Data.Accounts[key].Keys),
-			m.Data.Accounts[key].Status,
+			m.Data.Accounts[addr].Address,
+			strconv.Itoa(m.Data.Accounts[addr].Keys),
+			m.Data.Accounts[addr].Status,
 			expires,
-			strconv.Itoa(m.Data.Accounts[key].Balance),
+			strconv.Itoa(m.Data.Accounts[addr].Balance),
 		})
 	}
 	sort.SliceStable(rows, func(i, j int) bool {

--- a/ui/pages/accounts/model.go
+++ b/ui/pages/accounts/model.go
@@ -100,9 +100,7 @@ func (m ViewModel) makeRows() *[]table.Row {
 		}
 
 		if m.Data.Accounts[addr].NonResidentKey {
-			if expires == "⚠ EXPIRED" {
-				expires = "⚠ EXPIRED-NON-RESIDENT-KEY"
-			} else {
+			if expires != "⚠ EXPIRED" && expires != "EXPIRED" {
 				expires = "⚠ NON-RESIDENT-KEY"
 			}
 		}


### PR DESCRIPTION
# ℹ Overview

- refactors Account.Expires  
- refactors AccountsFromState to be more readable
- adds expired resident and non-resident keys


### ✅ Acceptance:
<!-- Use [X] to mark as completed -->

- [x] Pre-commit checks pass